### PR TITLE
Increase RUN POST timeout

### DIFF
--- a/fashn_viton.py
+++ b/fashn_viton.py
@@ -135,7 +135,7 @@ class FASHN:
 
         # Make API request
         session = requests.Session()
-        response = session.post(f"{ENDPOINT_URL}/run", headers=headers, json=inputs, timeout=10)
+        response = session.post(f"{ENDPOINT_URL}/run", headers=headers, json=inputs, timeout=60)
         response.raise_for_status()
         pred_id = response.json().get("id")
         pbar.update(1)


### PR DESCRIPTION
Since the call is taking longer than 10 seconds consistently, I propose this timeout time to be increased to at least 60 seconds.